### PR TITLE
chore: chunk cleanup

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,105 @@
+# Runs unit tests.
+name: unit
+
+on:
+    pull_request:
+    merge_group:
+    push:
+        branches: [main]
+
+env:
+    CARGO_TERM_COLOR: always
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    test:
+        # name: test / ${{ matrix.type }} (${{ matrix.partition }}/${{ matrix.total_partitions }})
+        name: test / ${{ matrix.type }}
+        runs-on: ubuntu-latest
+        env:
+            RUST_BACKTRACE: 1
+        strategy:
+            matrix:
+                include:
+                    - type: swarm
+                      args: ""
+                    # - type: ethereum
+                    #   args: --features "asm-keccak ethereum" --locked
+                    #   partition: 1
+                    #   total_partitions: 2
+                    # - type: ethereum
+                    #   args: --features "asm-keccak ethereum" --locked
+                    #   partition: 2
+                    #   total_partitions: 2
+                    # - type: optimism
+                    #   args: --features "asm-keccak optimism" --locked --exclude reth --exclude reth-bench --exclude "example-*" --exclude "reth-ethereum-*" --exclude "*-ethereum"
+                    #   partition: 1
+                    #   total_partitions: 2
+                    # - type: optimism
+                    #   args: --features "asm-keccak optimism" --locked --exclude reth --exclude reth-bench --exclude "example-*" --exclude "reth-ethereum-*" --exclude "*-ethereum"
+                    #   partition: 2
+                    #   total_partitions: 2
+                    # - type: book
+                    #   args: --manifest-path book/sources/Cargo.toml
+                    #   partition: 1
+                    #   total_partitions: 1
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@v4
+            - uses: rui314/setup-mold@v1
+            - uses: dtolnay/rust-toolchain@stable
+            - uses: Swatinem/rust-cache@v2
+              with:
+                  cache-on-failure: true
+            - uses: taiki-e/install-action@nextest
+            - if: "${{ matrix.type == 'book' }}"
+              uses: arduino/setup-protoc@v3
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Run tests
+              run: |
+                  cargo nextest run \
+                    ${{ matrix.args }} --workspace \
+                    --no-tests=warn \
+                    -E "!kind(test)"
+              # run: |
+              #     cargo nextest run \
+              #       ${{ matrix.args }} --workspace \
+              #       --no-tests=warn \
+              #       --partition hash:${{ matrix.partition }}/2 \
+              #       -E "!kind(test)"
+
+    doc:
+        name: doc tests (${{ matrix.network }})
+        runs-on: ubuntu-latest
+        env:
+            RUST_BACKTRACE: 1
+        timeout-minutes: 30
+        # strategy:
+        #     matrix:
+        #         network: ["ethereum", "optimism"]
+        steps:
+            - uses: actions/checkout@v4
+            - uses: rui314/setup-mold@v1
+            - uses: dtolnay/rust-toolchain@stable
+            - uses: Swatinem/rust-cache@v2
+              with:
+                  cache-on-failure: true
+            - name: Run doctests
+              # run: cargo test --doc --workspace --features "${{ matrix.network }}"
+              run: cargo test --doc --workspace
+
+    unit-success:
+        name: unit success
+        runs-on: ubuntu-latest
+        if: always()
+        needs: [test]
+        timeout-minutes: 30
+        steps:
+            - name: Decide whether the needed jobs succeeded or failed
+              uses: re-actors/alls-green@release/v1
+              with:
+                  jobs: ${{ toJSON(needs) }}

--- a/crates/primitives/src/chunk/bmt_body.rs
+++ b/crates/primitives/src/chunk/bmt_body.rs
@@ -87,7 +87,7 @@ impl ChunkData for BMTBody {
 
 impl ChunkBody for BMTBody {
     fn hash(&self) -> ChunkAddress {
-        self.cached_hash.get_or_init(|| self.hash()).clone()
+        *self.cached_hash.get_or_init(|| self.hash())
     }
 }
 
@@ -231,7 +231,7 @@ impl TryFrom<Bytes> for BMTBody {
 
         // SAFETY: bytes.len() >= SPAN_SIZE
         let span = Span::from_le_bytes(buf.split_to(SPAN_SIZE).as_ref().try_into()?);
-        Ok(BMTBody::builder().with_span(span).with_data(buf)?.build()?)
+        BMTBody::builder().with_span(span).with_data(buf)?.build()
     }
 }
 
@@ -249,7 +249,7 @@ impl<'a> arbitrary::Arbitrary<'a> for BMTBody {
         let span = Span::arbitrary(u)?;
 
         // Ensure data size does not exceed CHUNK_SIZE
-        let data_len: usize = u.int_in_range(0..=CHUNK_SIZE as usize)?;
+        let data_len: usize = u.int_in_range(0..=CHUNK_SIZE)?;
         let mut buf = vec![0; data_len];
         u.fill_buffer(&mut buf)?;
 


### PR DESCRIPTION
This PR:

1. Adds a Github actions workflow for running unit tests.
2. Applies clippy fixes to the chunk module
3. Simplifies testing to remove extraneous `unwrap` in favour of returning a result in a test (not for proptests).